### PR TITLE
Create holder.txt

### DIFF
--- a/MusiQueue-server/holder.txt
+++ b/MusiQueue-server/holder.txt
@@ -1,0 +1,1 @@
+holder file until we get server files in here


### PR DESCRIPTION
Inserting text file to keep holder folder for server side.  .gitignore file is causing issues with cloning the repo.