### PR TITLE
Fixed app-breaking bug in when searching for a song+showing users.

### DIFF
--- a/MusiQueue-android/app/src/main/java/com/example/vince/youtubeplayertest/Activities/hub_admin_only/QueueActivity.java
+++ b/MusiQueue-android/app/src/main/java/com/example/vince/youtubeplayertest/Activities/hub_admin_only/QueueActivity.java
@@ -370,6 +370,7 @@ public class QueueActivity extends AppCompatActivity implements UpdateResultRece
                 changeAndUpdate("add");
                 videosFound.setVisibility(View.GONE);
                 songListView.setVisibility(View.VISIBLE);
+                userListView.setVisibility(View.GONE);
             }
 
         });


### PR DESCRIPTION
The code was just setting the songs list view to visible so both users list and song list were visible on top of each other and crashing the app.  Updated to go back to the song list when enqueuing a song.